### PR TITLE
Update stereoCameraSettingsDialog.cpp

### DIFF
--- a/src/subwindows/stereoCameraSettingsDialog.cpp
+++ b/src/subwindows/stereoCameraSettingsDialog.cpp
@@ -374,7 +374,7 @@ void StereoCameraSettingsDialog::startHardwareTrigger() {
     double fps = triggerFramerateInputBox->value();
 
     int delay = (int)(((1000.0f/fps)*1000.0f) / 2.0f);
-    int count = (int)(runtime*60000000)/(delay*2);
+    int count = (int)((runtime*60000000)/(delay*2));
 
 
     QString cmd = "<TX"+ QString::number(count) +"X"+ QString::number(delay) +">";


### PR DESCRIPTION
(runtime * 60000000) resulted in integer overflow for any runtime higher than approximately 35 if cast into an integer. Putting the division in brackets this should stay as a double during division, and only cast into an integer when the value is smaller, allowing for much higher runtime without error.